### PR TITLE
Add AI SAFE² v3.1 release package

### DIFF
--- a/ANNOUNCEMENT-v3.1.md
+++ b/ANNOUNCEMENT-v3.1.md
@@ -1,0 +1,268 @@
+# AI SAFE² v3.1: Protocol-Independent Governance, Three Enforcement Planes, and Agent-Ready Distribution
+
+<p align="center">
+  <img alt="AI SAFE2 v3.1" src="https://img.shields.io/badge/AI%20SAFE%C2%B2-v3.1.0-F6921E?style=for-the-badge">
+  <img alt="Framework" src="https://img.shields.io/badge/Framework-161%20Controls-820F1A?style=for-the-badge">
+  <img alt="MCP Profile" src="https://img.shields.io/badge/CP.5.MCP-19%20Controls-F6921E?style=for-the-badge">
+  <img alt="Agent Ready" src="https://img.shields.io/badge/Agent%20Discovery-Validated-808080?style=for-the-badge">
+</p>
+
+**Cyber Strategy Institute | August 2026**
+
+AI SAFE² v3.1 is the release where protocol governance stops depending on protocol-owned state.
+
+The trigger was MCP `2026-07-28`. MCP moved to a stateless core and removed constructs that earlier AI SAFE² MCP controls had used as governance anchors. The result exposed a framework design defect: if a protocol owns the thing a control binds to, the protocol can remove that thing.
+
+v3.1 fixes the defect at the architecture level, extends enforcement across the agent-to-tool plane, adds six MCP controls, formalizes a common persistence vocabulary, strengthens NEXUS compatibility behavior, expands scanner coverage, upgrades the Challenge Lab, standardizes the entire repository experience, and adds a deterministic machine entry point so agents and compliance bots can consume the framework without scraping prose.
+
+The normative rule is now:
+
+> **A CP.5 profile MUST NOT bind a control to a construct owned by the protocol it profiles.**
+
+AI SAFE² v3.1 binds governance to framework-owned constructs: verified principals, capability grants, provenance baselines, delegation chains, governed state handles, policy decisions, and evidence.
+
+---
+
+## Fast Action
+
+| If you want to... | Go here |
+|:---|:---|
+| **Understand v3.1 in 5 minutes** | [v3.1 Release Overview](guides/v3.1-release-overview.md) |
+| **Start from the framework** | [AI SAFE² v3.1 README](README.md) |
+| **Implement MCP controls** | [CP.5.MCP Security Profile](00-cross-pillar/cp5_mcp_server_security.md) |
+| **Use the machine-readable MCP profile** | [MCP Profile JSON](skills/mcp/data/mcp-profile-v3.1.json) |
+| **Use the 161-control core dataset** | [Core Control JSON](skills/mcp/data/ai-safe2-controls-v3.0.json) |
+| **Integrate from an AI agent or bot** | [AGENTS.md](AGENTS.md) and [ai-safe2.manifest.json](ai-safe2.manifest.json) |
+| **Assess code or deployments** | [Scanner](scanner/) |
+| **Secure MCP implementations** | [MCP Security Toolkit](examples/mcp-security-toolkit/) |
+| **Use CSI's reference implementation** | [NEXUS](NEXUS/) |
+| **Review maturity and threat mapping** | [AISM](AISM/) |
+| **See governed implementation patterns** | [Examples](examples/) |
+| **Read the evidence base** | [Research](research/) |
+| **Challenge or falsify the framework** | [Challenge Lab](challenges/) |
+| **Explore controls interactively** | [AI SAFE² Dashboard](https://cyberstrategyinstitute.github.io/ai-safe2-framework/dashboard/) |
+| **Review repository UX rules** | [Repository UX Standard](docs/REPOSITORY-UX-STANDARD.md) |
+| **See the release history** | [GitHub Releases](https://github.com/CyberStrategyInstitute/ai-safe2-framework/releases) |
+
+---
+
+## What changed
+
+### 1. MCP governance was re-anchored
+
+MCP `2026-07-28` removed the protocol assumptions that exposed the flaw in our earlier CP.5.MCP design. Five existing controls were re-anchored from session concepts to verified principals and framework-owned state.
+
+The MCP profile now contains **19 controls**, MCP-1 through MCP-19. The AI SAFE² framework total remains **161 controls**.
+
+| Change | v3.1 result |
+|:---|:---|
+| **Re-anchored controls** | MCP-4, MCP-7, MCP-8, MCP-11, MCP-13 bind to framework-owned governance state rather than protocol session state |
+| **MCP-14** | Extension Capability Negotiation |
+| **MCP-15** | Header and Body Assertion Integrity |
+| **MCP-16** | State Handle Binding and Lifecycle |
+| **MCP-17** | MRTR Round-Trip Integrity and Replay Resistance |
+| **MCP-18** | Catalog Cache Integrity and Provenance Revalidation |
+| **MCP-19** | Authorization Chain Integrity, intended-resource/audience binding, and SSRF boundaries |
+| **Primary binding** | MCP `2026-07-28` |
+| **Legacy compatibility** | MCP `2025-11-25` for a twelve-month migration window |
+
+`server/discover` is optional under the primary MCP binding. AI SAFE² does not require it and the scanner does not treat its absence as a failure.
+
+`Mcp-Session-Id`, where encountered in the legacy binding, is a principal-scoped state handle. It is not identity and is not the authorization boundary.
+
+### 2. Three enforcement planes are now explicit
+
+AI SAFE² v3.1 treats agentic governance as a three-plane problem:
+
+| Plane | Traffic | Primary governance problem |
+|:---|:---|:---|
+| **North-south** | Agent to model provider | Content, policy, spend, provider access |
+| **East-west** | Agent to agent | Identity, delegation, lineage, authority |
+| **Agent-to-tool** | Agent to MCP server or tool | Tool authorization, provenance, catalog trust, returned-content risk |
+
+A successful control or challenge result on one plane does not automatically establish coverage on another.
+
+### 3. Persistence vocabulary is protocol-independent
+
+New evidence and integrations use:
+
+- `request`
+- `handle_scoped`
+- `durable`
+- `swarm_shared`
+
+Legacy NEXUS values remain accepted as compatibility aliases:
+
+- `SESSION` -> `request`
+- `CROSS_SESSION` -> `handle_scoped`
+- `PERMANENT` -> `durable`
+
+This removes protocol session language from the governance boundary while preserving migration compatibility.
+
+### 4. NEXUS is clearly positioned as the CSI reference implementation
+
+**AI SAFE² is the governance and requirements standard. NEXUS is CSI's first-party reference implementation.**
+
+Organizations may use NEXUS or another implementation that demonstrably satisfies the applicable AI SAFE² controls and evidence requirements.
+
+NEXUS remains **v0.3** under the AI SAFE² v3.1 framework release. Gateway remains **v3.0** until a separately tested Gateway component release changes it.
+
+The NEXUS MCP adapter is fail-closed scaffolding. **Status: not production-ready.** Unimplemented enforcement methods raise rather than silently allowing traffic.
+
+### 5. Scanner coverage expanded
+
+The v3.1 registry contains **64 scanner rules**:
+
+- 52 pre-existing scanner rules
+- 12 new grouped CP.5.MCP v3.1 rules
+
+MCP-19 findings remain advisory where static analysis cannot prove deployment-specific intended-resource or audience binding.
+
+### 6. MCP-19 now has an explicit conformance boundary
+
+Opaque bearer-token possession does not prove audience or intended-resource validation.
+
+A deployment must not claim MCP-19 audience/resource conformance unless it can evidence intended-resource, audience, or equivalent binding before protected dispatch.
+
+This is intentionally stricter than "the token was accepted."
+
+### 7. Challenge Lab is now scoped by enforcement plane
+
+Challenge 001 and the broader Challenge Lab now separate:
+
+- challenge maturity;
+- framework/profile conformance;
+- the enforcement plane actually exercised;
+- evidence required to support a claim.
+
+The v3.1 MCP cases include header/body desynchronization, catalog/schema drift, replay, audience/resource confusion, endpoint impersonation, SSRF, and legacy state-handle misuse.
+
+[Open the Challenge Lab](challenges/)
+
+### 8. The repository now has one human experience
+
+The v3.1 consistency sweep standardizes the root framework, Pillar 1 through 5, Cross-Pillar Governance, AISM, NEXUS, Scanner, Gateway, Skills, MCP, Dashboard, Examples, Research, Challenge Lab, and UAS surfaces.
+
+Repository color semantics are explicit:
+
+- ![Release](https://img.shields.io/badge/Release-F6921E-F6921E) **CSI Orange `#F6921E`** for current release/version context
+- ![Framework](https://img.shields.io/badge/Framework-820F1A-820F1A) **CSI Maroon `#820F1A`** for framework/module identity
+- ![Neutral](https://img.shields.io/badge/Neutral-808080-808080) **Gray `#808080`** for neutral/status context
+- red/amber/yellow remain reserved for risk and severity
+- green remains reserved for verified/pass states
+
+All 18 direct example README surfaces and all 24 numbered research notes now use the common v3.1 navigation and context shell while preserving legitimate historical provenance.
+
+### 9. Agents and bots now have a first-class entry point
+
+AI SAFE² v3.1 no longer requires an automated consumer to infer the repository structure from prose.
+
+Start with:
+
+1. [AGENTS.md](AGENTS.md)
+2. [ai-safe2.manifest.json](ai-safe2.manifest.json)
+3. [161-control core JSON](skills/mcp/data/ai-safe2-controls-v3.0.json)
+4. [19-control MCP v3.1 profile JSON](skills/mcp/data/mcp-profile-v3.1.json)
+
+The manifest exposes framework version, component versions, normative paths, control counts, enforcement planes, persistence vocabulary, conformance boundaries, implementation status, and machine-readable datasets.
+
+A dedicated **Agent Discovery and Manifest Integrity** CI gate verifies those claims against the repository.
+
+---
+
+## What did not change
+
+v3.1 is not a renumbering exercise.
+
+- The **161-control core remains unchanged**.
+- CP.1 through CP.10 remain the Cross-Pillar Governance layer.
+- CP.11 UAS remains a compliance overlay rather than 27 new core controls.
+- Historical v3.0 references remain where they accurately describe when a capability, research result, example, or component was introduced.
+- NEXUS remains v0.3.
+- Gateway remains v3.0.
+
+The stable core dataset retains the filename `ai-safe2-controls-v3.0.json` because that dataset represents the unchanged 161-control taxonomy introduced in v3.0. The v3.1 MCP changes are maintained as a separate profile overlay.
+
+---
+
+## Release validation
+
+The v3.1 release candidate is exercised by dedicated repository gates covering:
+
+- repository UX and navigation consistency;
+- examples and research index integrity;
+- agent discovery and manifest integrity;
+- scanner v3.1 invariants;
+- NEXUS persistence compatibility;
+- MCP profile/dashboard parity and 161/19 control-count invariants;
+- NEXUS tests on Python 3.10, 3.11, and 3.12;
+- release-critical Python correctness;
+- NEXUS schema validation;
+- NEXUS reference-example smoke tests;
+- NEXUS v0.3 implementation/compliance checks;
+- documentation validation;
+- AI SAFE² Skill Trust Gate validation.
+
+The release is designed to fail on incorrect claims and broken paths, not only on syntax.
+
+---
+
+## Read next
+
+### Framework and governance
+
+- [AI SAFE² v3.1 Framework](README.md)
+- [Cross-Pillar Governance](00-cross-pillar/)
+- [CP.5.MCP Security Profile](00-cross-pillar/cp5_mcp_server_security.md)
+- [AISM](AISM/)
+- [AISM Agent Threat and Control Matrix](AISM/agent-threat-control-matrix.md)
+- [v3.1 Release Overview](guides/v3.1-release-overview.md)
+
+### Implementation
+
+- [NEXUS](NEXUS/)
+- [Scanner](scanner/)
+- [MCP Security Toolkit](examples/mcp-security-toolkit/)
+- [AI SAFE² MCP Server](skills/mcp/)
+- [Sovereign Runtime Examples](examples/)
+- [Dashboard](https://cyberstrategyinstitute.github.io/ai-safe2-framework/dashboard/)
+
+### Evidence and validation
+
+- [Research Index](research/)
+- [Research 023: MCP Server Security Profile](research/023_mcp-server-security-profile.md)
+- [Research 024: MCP Consumer Protection](research/024_mcp_consumer_protection.md)
+- [Challenge Lab](challenges/)
+- [Challenge 001](challenges/001-anthropic-multi-agent-turf-war/)
+
+### Machine consumption
+
+- [AGENTS.md](AGENTS.md)
+- [AI SAFE² Manifest](ai-safe2.manifest.json)
+- [Core Controls JSON](skills/mcp/data/ai-safe2-controls-v3.0.json)
+- [MCP v3.1 Profile JSON](skills/mcp/data/mcp-profile-v3.1.json)
+
+### External
+
+- [AI SAFE²](https://cyberstrategyinstitute.com/ai-safe2/)
+- [NEXUS](https://cyberstrategyinstitute.com/nexus/)
+- [Implementation Toolkit](https://secure.cyberstrategyinstitute.com/ai-safe-implementation-toolkit/)
+- [MCP 2026-07-28 Specification](https://modelcontextprotocol.io/specification/2026-07-28)
+- [MCP 2026-07-28 Release Announcement](https://blog.modelcontextprotocol.io/posts/2026-07-28/)
+- [MCP Security Best Practices](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices)
+
+---
+
+## The operating principle
+
+**Policy defines intent. Engineering must enforce reality.**
+
+If governance is not enforced at runtime, it is not governance.
+
+AI SAFE² v3.1 makes that contract more durable by making the governance boundary ours, not the protocol's.
+
+---
+
+Framework content CC-BY-SA 4.0. Code MIT. NEXUS Apache 2.0.
+
+*Cyber Strategy Institute*

--- a/guides/v3.1-release-overview.md
+++ b/guides/v3.1-release-overview.md
@@ -1,0 +1,702 @@
+# AI SAFE² v3.1 - Complete Release Overview
+
+<p align="center">
+  <img alt="AI SAFE2 v3.1" src="https://img.shields.io/badge/AI%20SAFE%C2%B2-v3.1.0-F6921E?style=for-the-badge">
+  <img alt="Framework" src="https://img.shields.io/badge/Core-161%20Controls-820F1A?style=for-the-badge">
+  <img alt="MCP" src="https://img.shields.io/badge/CP.5.MCP-19%20Controls-F6921E?style=for-the-badge">
+  <img alt="Agent Ready" src="https://img.shields.io/badge/Machine%20Entry-Validated-808080?style=for-the-badge">
+</p>
+
+**Cyber Strategy Institute | August 2026**  
+**The definitive reference for what AI SAFE² v3.1 changes, preserves, and enables.**
+
+[Framework Home](../README.md) · [v3.1 Announcement](../ANNOUNCEMENT-v3.1.md) · [Cross-Pillar Governance](../00-cross-pillar/) · [MCP Profile](../00-cross-pillar/cp5_mcp_server_security.md) · [NEXUS](../NEXUS/) · [Scanner](../scanner/) · [Examples](../examples/) · [Research](../research/) · [Challenge Lab](../challenges/) · [Dashboard](https://cyberstrategyinstitute.github.io/ai-safe2-framework/dashboard/)
+
+---
+
+## Navigation
+
+| Section | What it covers |
+|:---|:---|
+| [The one-line case](#the-one-line-case) | Why v3.1 matters |
+| [Part I: What changed](#part-i-what-changed) | Protocol independence, MCP 2026-07-28, three planes, persistence |
+| [Part II: MCP profile](#part-ii-the-cp5mcp-v31-profile) | Re-anchored controls and MCP-14 through MCP-19 |
+| [Part III: NEXUS and implementation](#part-iii-nexus-and-reference-implementation) | NEXUS positioning, compatibility, adapter status |
+| [Part IV: Scanner and evidence](#part-iv-scanner-evidence-and-validation) | Scanner, Challenge Lab, release gates |
+| [Part V: Human repository UX](#part-v-one-repository-one-product-experience) | Navigation, colors, examples, research |
+| [Part VI: Agent and bot consumption](#part-vi-agent-and-bot-consumption) | AGENTS.md, manifest, machine data |
+| [Part VII: What did not change](#part-vii-what-v31-does-not-change) | 161 core, component versions, provenance |
+| [Part VIII: How to use v3.1](#part-viii-how-to-use-v31) | Fast paths by audience |
+| [Release checklist](#release-readiness-checklist) | What should be verified before publication |
+
+---
+
+## The one-line case
+
+AI SAFE² v3.1 makes agentic governance durable across protocol change by moving the governance boundary away from protocol-owned constructs and into framework-owned identity, authority, provenance, state, and evidence.
+
+v3.0 transformed AI SAFE² into a governance operating system. v3.1 hardens that operating system so a protocol revision cannot silently invalidate its controls.
+
+---
+
+# Part I: What changed
+
+## 1. The design defect v3.1 fixes
+
+The MCP `2026-07-28` specification removed the session-oriented assumptions that earlier CP.5.MCP controls had relied on.
+
+That exposed a framework defect on our side, not a protocol defect.
+
+The old pattern was effectively:
+
+```text
+protocol construct -> control anchor -> governance claim
+```
+
+If the protocol removed the construct, the governance claim lost its anchor.
+
+v3.1 replaces that with:
+
+```text
+framework-owned governance construct -> protocol adapter -> implementation evidence
+```
+
+The normative rule is:
+
+> **A CP.5 profile MUST NOT bind a control to a construct owned by the protocol it profiles.**
+
+This rule applies beyond MCP. It is the design requirement for every future CP.5 protocol or platform profile.
+
+## 2. Framework-owned constructs
+
+Controls now bind to concepts AI SAFE² owns and can preserve across protocol revisions:
+
+- verified principal identity;
+- capability grants;
+- delegation chains;
+- provenance baselines;
+- governed persistence scopes;
+- principal-scoped state handles;
+- authorization decisions;
+- policy evidence;
+- trust-establishment events;
+- implementation and evidence provenance.
+
+The protocol supplies transport and capability semantics. It no longer owns the governance boundary.
+
+## 3. Three enforcement planes
+
+v3.1 formalizes three distinct enforcement planes.
+
+| Plane | Traffic | Typical risks | Primary enforcement concern |
+|:---|:---|:---|:---|
+| **North-south** | Agent to model provider | prompt/content policy, provider access, spend | content, policy, consumption, provider boundary |
+| **East-west** | Agent to agent | delegation abuse, NHI confusion, replication, lineage loss | identity, authority, delegation, provenance |
+| **Agent-to-tool** | Agent to MCP server or tool | tool misuse, catalog poisoning, SSRF, authorization confusion | tool authorization, state, provenance, returned-content trust |
+
+A control can span more than one plane, but evidence remains plane-specific. Passing an east-west challenge does not establish agent-to-tool conformance.
+
+## 4. Protocol-independent persistence
+
+v3.1 standardizes persistence language so governance is not attached to a transport session.
+
+Canonical scopes:
+
+| Scope | Meaning |
+|:---|:---|
+| `request` | effect ends with the current request or interaction |
+| `handle_scoped` | effect persists through an explicitly governed state handle |
+| `durable` | effect survives request and state-handle lifecycle |
+| `swarm_shared` | governed durable state shared across agents |
+
+Legacy NEXUS aliases remain accepted for migration:
+
+| Legacy | Canonical v3.1 |
+|:---|:---|
+| `SESSION` | `request` |
+| `CROSS_SESSION` | `handle_scoped` |
+| `PERMANENT` | `durable` |
+
+These aliases are compatibility vocabulary. They are not identity or authorization boundaries.
+
+---
+
+# Part II: The CP.5.MCP v3.1 profile
+
+## 1. Control count model
+
+AI SAFE² remains a **161-control framework**.
+
+CP.5.MCP is a profile under the framework. The v3.1 MCP profile contains **19 profile controls**, MCP-1 through MCP-19.
+
+The 19 profile controls are not added to 161 to create a 180-control framework. They are implementation-specific requirements under CP.5.
+
+Machine-readable sources:
+
+- [161-control core dataset](../skills/mcp/data/ai-safe2-controls-v3.0.json)
+- [19-control MCP v3.1 profile](../skills/mcp/data/mcp-profile-v3.1.json)
+
+## 2. Existing controls re-anchored
+
+Five controls required material semantic changes because they were previously tied to session concepts:
+
+- MCP-4
+- MCP-7
+- MCP-8
+- MCP-11
+- MCP-13
+
+They now bind to verified principals and framework-owned governance state.
+
+MCP-8 is the clearest example. A spend ceiling expressed per transport session is not enforceable if no transport session exists. A spend ceiling tied to a verified principal, capability, delegation context, or governed accounting identity survives the protocol revision.
+
+## 3. Six new controls
+
+### MCP-14: Extension Capability Negotiation
+
+Requires explicit negotiation and validation of extension capabilities rather than silently assuming optional behavior is present or trustworthy.
+
+### MCP-15: Header and Body Assertion Integrity
+
+Protects against authorization and routing decisions being made from one asserted operation while the server dispatches another.
+
+A mismatch between header-level method/name assertions and body content is treated as a security event, not benign drift.
+
+### MCP-16: State Handle Binding and Lifecycle
+
+Requires governed state handles to be bound to the correct principal and lifecycle, without treating the handle itself as identity.
+
+### MCP-17: MRTR Round-Trip Integrity and Replay Resistance
+
+Governs Multi Round-Trip Request answers, replay resistance, response binding, and consent-state integrity.
+
+This matters when human approval, Class-H authorization, or delegated decision state is carried through the round-trip.
+
+### MCP-18: Catalog Cache Integrity and Provenance Revalidation
+
+Addresses cache poisoning, stale revocation, tool catalog drift, schema drift, and untrusted server-declared TTL behavior.
+
+The local consumer must retain authority over acceptable cache duration and provenance revalidation.
+
+### MCP-19: Authorization Chain Integrity
+
+Requires intended-resource, audience, or equivalent authorization binding through the protected dispatch path and adds SSRF/resource-boundary requirements.
+
+Possession of an opaque bearer token is not sufficient evidence.
+
+## 4. Compatibility model
+
+Primary specification binding:
+
+- MCP `2026-07-28`
+
+Legacy compatibility binding:
+
+- MCP `2025-11-25`
+- twelve-month migration window
+
+Important behavior:
+
+- `server/discover` is optional under `2026-07-28`;
+- its absence is not a conformance failure;
+- legacy `Mcp-Session-Id` can be carried as a principal-scoped state handle;
+- it is not identity;
+- it is not the authorization boundary.
+
+## 5. New threat emphasis
+
+v3.1 explicitly treats agent-to-tool protocol exploitation as a first-class threat surface.
+
+The release work includes cases for:
+
+- header/body assertion desynchronization;
+- stale or poisoned catalog caches;
+- catalog and schema drift;
+- OAuth resource and audience confusion;
+- replay;
+- endpoint identity confusion and local impersonation;
+- redirect and resource SSRF;
+- state-handle identity misuse.
+
+---
+
+# Part III: NEXUS and reference implementation
+
+## 1. NEXUS positioning
+
+AI SAFE² and NEXUS serve different roles.
+
+**AI SAFE²** defines governance outcomes, controls, evidence expectations, and conformance requirements.
+
+**NEXUS** is Cyber Strategy Institute's first-party reference implementation for enforcing those requirements across agent-to-agent and agent-to-tool interactions.
+
+NEXUS is not mandatory for AI SAFE² conformance.
+
+Another implementation may conform if it demonstrably satisfies the applicable control outcome and produces the required evidence.
+
+This is the correct relationship:
+
+```text
+AI SAFE² requirement
+        |
+        v
+reference implementation or alternative implementation
+        |
+        v
+runtime evidence
+        |
+        v
+conformance claim
+```
+
+## 2. Component versions remain independent
+
+| Component | Version in this release |
+|:---|:---|
+| AI SAFE² Framework | **v3.1.0** |
+| NEXUS | **v0.3** |
+| Gateway | **v3.0** |
+
+Repository branding does not overwrite component provenance.
+
+A Gateway v3.0 evidence chain remains Gateway v3.0 evidence. NEXUS v0.3 remains NEXUS v0.3.
+
+## 3. NEXUS persistence compatibility
+
+The NEXUS Memory SDK now emits the canonical persistence vocabulary while accepting legacy serialized values.
+
+The migration path is designed to preserve old callers and evidence consumers without allowing old terms to remain the normative governance model.
+
+Updated implementation surfaces include:
+
+- NEXUS Memory SDK;
+- Guardian schema;
+- OPA authorization policy;
+- OPA invariants;
+- compatibility regression tests;
+- reference examples.
+
+## 4. ACS bridge example
+
+The ACS bridge reference example now:
+
+- runs under the project's Python 3.10+ support model;
+- demonstrates `handle_scoped` rather than the legacy `CROSS_SESSION` term;
+- emits the governed state-handle evidence fields;
+- preserves ACS protocol correlation semantics where they are legitimately protocol-owned.
+
+## 5. MCP adapter status
+
+The NEXUS MCP adapter is a fail-closed interface scaffold.
+
+**Status: not production-ready.**
+
+Unimplemented enforcement paths raise rather than silently allowing traffic.
+
+That distinction is explicitly represented in both human and machine-facing release material so downstream users and agents cannot reasonably infer production conformance from the existence of the adapter.
+
+---
+
+# Part IV: Scanner, evidence, and validation
+
+## 1. Scanner rule expansion
+
+The v3.1 scanner registry contains **64 total rules**:
+
+- 52 pre-existing rules;
+- 12 new grouped CP.5.MCP v3.1 rules.
+
+The scanner now recognizes v3.1 MCP patterns without pretending that static analysis can prove every deployment property.
+
+MCP-19 resource/audience findings therefore remain advisory when runtime evidence is required.
+
+## 2. Scanner is evidence, not conformance by itself
+
+A scanner result is one evidence source.
+
+It does not prove:
+
+- runtime policy enforcement;
+- delegated authority correctness;
+- intended-resource binding at dispatch;
+- human authorization integrity;
+- runtime catalog revalidation;
+- full framework conformance.
+
+This separation is important for both humans and automated compliance systems.
+
+## 3. Challenge Lab changes
+
+The Challenge Lab now separates:
+
+- `challenge_maturity`;
+- `framework_profile_conformance`;
+- enforcement plane;
+- implementation under test;
+- evidence required for the claim.
+
+Challenge 001 includes new v3.1 MCP attack cases and evidence fields.
+
+The framework is the subject of the experiment, not the source of its own proof.
+
+Useful links:
+
+- [Challenge Lab](../challenges/)
+- [Challenge 001](../challenges/001-anthropic-multi-agent-turf-war/)
+- [Challenge Evidence](../challenges/001-anthropic-multi-agent-turf-war/EVIDENCE.md)
+
+## 4. Release validation gates
+
+The v3.1 release work adds or strengthens validation for:
+
+1. repository UX and navigation consistency;
+2. examples index integrity;
+3. research index completeness;
+4. scanner v3.1 rule invariants;
+5. NEXUS persistence compatibility;
+6. MCP profile/dashboard data parity;
+7. 161-core/19-profile control count invariants;
+8. NEXUS tests on Python 3.10, 3.11, and 3.12;
+9. release-critical Python correctness;
+10. NEXUS schema validation;
+11. NEXUS reference-example smoke tests;
+12. NEXUS v0.3 implementation/compliance checks;
+13. documentation validation;
+14. Skill Trust Gate checks;
+15. machine-entry and manifest integrity.
+
+The objective is not merely to make CI green. The gates encode release claims so the repository fails when the release narrative and the implementation diverge.
+
+---
+
+# Part V: One repository, one product experience
+
+v3.1 includes a repository-wide UX consistency pass.
+
+The target user experience is simple: a user should be able to land anywhere in the repository and understand where they are, what version applies, how to get back to the framework, and which adjacent resources matter.
+
+## 1. Standard color language
+
+- **CSI Orange `#F6921E`**: current framework release and version context
+- **CSI Maroon `#820F1A`**: framework, governance, module, and surface identity
+- **Gray `#808080`**: neutral, metadata, and status context
+- red/amber/yellow: severity and risk only
+- green: pass or verified states only
+
+The standard is documented in:
+
+[Repository UX Standard](../docs/REPOSITORY-UX-STANDARD.md)
+
+## 2. Canonical navigation
+
+Common entry points include:
+
+- Framework Home;
+- Cross-Pillar Governance;
+- AISM;
+- NEXUS;
+- context-specific parent or adjacent resources.
+
+The old broken `cross-pillar/` path pattern is replaced by the canonical `00-cross-pillar/` path.
+
+## 3. Examples
+
+All 18 direct example README surfaces now have a consistent v3.1 shell and an indexed landing page:
+
+[Examples Index](../examples/)
+
+Historical implementation references are preserved when they accurately describe provenance.
+
+## 4. Research
+
+All 24 numbered research notes now have consistent navigation and a canonical index:
+
+[Research Index](../research/)
+
+The research body remains evidence and publication history. Current normative implementation guidance comes from the v3.1 framework surfaces.
+
+---
+
+# Part VI: Agent and bot consumption
+
+This is one of the most important distribution changes in v3.1.
+
+Before this release, an AI agent could use the repository, but it had to infer authority and structure from human prose.
+
+v3.1 adds deterministic machine discovery.
+
+## 1. AGENTS.md
+
+[AGENTS.md](../AGENTS.md) is the root machine-consumption guide.
+
+It tells automated consumers:
+
+- what to parse first;
+- which datasets are authoritative for which purpose;
+- how to distinguish core controls from profiles;
+- how to classify enforcement planes;
+- how to interpret persistence;
+- how to handle legacy aliases;
+- how to treat `server/discover`;
+- how to treat bearer tokens and MCP-19;
+- how to treat the NEXUS MCP adapter;
+- how to avoid false conformance claims.
+
+## 2. ai-safe2.manifest.json
+
+[ai-safe2.manifest.json](../ai-safe2.manifest.json) is the machine-readable root manifest.
+
+It exposes:
+
+- framework version;
+- control counts;
+- component versions;
+- normative paths;
+- machine-readable datasets;
+- enforcement planes;
+- persistence vocabulary;
+- compatibility rules;
+- implementation status;
+- conformance boundaries;
+- scanner and challenge resources.
+
+## 3. Stable core plus overlay model
+
+The data model is intentionally layered.
+
+### Stable core
+
+`skills/mcp/data/ai-safe2-controls-v3.0.json`
+
+This remains the canonical 161-control dataset because the core taxonomy is unchanged from v3.0.
+
+### Current profile overlay
+
+`skills/mcp/data/mcp-profile-v3.1.json`
+
+This contains the 19 current CP.5.MCP profile controls.
+
+An automated consumer should not merge the two counts into a 180-control framework total.
+
+## 4. Manifest integrity gate
+
+A dedicated CI job validates machine-facing release claims against the actual repository.
+
+It checks, among other things:
+
+- framework version;
+- component versions;
+- required paths;
+- 161/19 count split;
+- MCP spec version;
+- profile/dashboard parity;
+- canonical persistence scopes;
+- NEXUS non-mandatory positioning;
+- explicit non-production status of the MCP adapter.
+
+This makes agent-readiness a tested release property rather than a documentation promise.
+
+---
+
+# Part VII: What v3.1 does not change
+
+## 1. The core framework remains 161 controls
+
+v3.1 does not add the MCP profile controls to the framework total.
+
+The framework remains:
+
+- five operational pillars;
+- Cross-Pillar Governance CP.1 through CP.10;
+- 161 core controls.
+
+## 2. CP.11 UAS remains an overlay
+
+The UAS material does not add 27 independent controls to the core framework count.
+
+It remains a compliance overlay applied to the framework.
+
+## 3. Historical v3.0 references are not automatically wrong
+
+Some documents, examples, and evidence correctly say v3.0 because that is when the underlying capability or result was introduced.
+
+v3.1 preserves those references when they are provenance.
+
+The distinction is:
+
+- **current normative framework guidance** -> v3.1;
+- **historical publication or component provenance** -> preserve the actual version.
+
+## 4. Gateway does not become v3.1
+
+Gateway remains v3.0 until the component itself receives a separately tested release.
+
+## 5. NEXUS does not become v3.1
+
+NEXUS remains v0.3.
+
+The framework release and implementation release are different version axes.
+
+---
+
+# Part VIII: How to use v3.1
+
+## If you are an executive, CISO, or governance owner
+
+Start here:
+
+1. [Framework README](../README.md)
+2. [Cross-Pillar Governance](../00-cross-pillar/)
+3. [AISM](../AISM/)
+4. [Challenge Lab](../challenges/)
+
+Key question to ask:
+
+**Where is the enforcement point, and what evidence proves the control operates there?**
+
+## If you are an engineer or platform team
+
+Start here:
+
+1. [CP.5.MCP Security Profile](../00-cross-pillar/cp5_mcp_server_security.md)
+2. [Scanner](../scanner/)
+3. [MCP Security Toolkit](../examples/mcp-security-toolkit/)
+4. [NEXUS](../NEXUS/)
+5. [Examples](../examples/)
+
+Key question to ask:
+
+**Which plane am I enforcing, and what framework-owned identity/state construct survives protocol changes?**
+
+## If you operate an MCP server or client
+
+Start here:
+
+1. [MCP profile](../00-cross-pillar/cp5_mcp_server_security.md)
+2. [Research 023](../research/023_mcp-server-security-profile.md)
+3. [Research 024](../research/024_mcp_consumer_protection.md)
+4. [MCP Toolkit](../examples/mcp-security-toolkit/)
+
+Pay special attention to:
+
+- MCP-15 assertion integrity;
+- MCP-16 state-handle binding;
+- MCP-17 replay and MRTR integrity;
+- MCP-18 cache provenance;
+- MCP-19 intended-resource/audience binding.
+
+## If you are building an autonomous agent
+
+Start here:
+
+1. [AISM](../AISM/)
+2. [NEXUS](../NEXUS/)
+3. [Examples](../examples/)
+4. [Challenge Lab](../challenges/)
+
+Classify the agent's ACT tier before treating implementation guidance as complete.
+
+## If you are an AI agent, coding assistant, compliance bot, or retrieval system
+
+Start here:
+
+1. [AGENTS.md](../AGENTS.md)
+2. [ai-safe2.manifest.json](../ai-safe2.manifest.json)
+3. [Core dataset](../skills/mcp/data/ai-safe2-controls-v3.0.json)
+4. [MCP profile dataset](../skills/mcp/data/mcp-profile-v3.1.json)
+
+Do not infer framework conformance from scanner results, component presence, or protocol session state.
+
+## If you want to challenge the framework
+
+Start here:
+
+1. [Challenge Lab](../challenges/)
+2. [Challenge 001](../challenges/001-anthropic-multi-agent-turf-war/)
+3. [Evidence requirements](../challenges/001-anthropic-multi-agent-turf-war/EVIDENCE.md)
+
+The objective is falsification, not confirmation.
+
+---
+
+# Release readiness checklist
+
+Before publishing v3.1, verify all of the following:
+
+- [ ] framework version is represented as v3.1.0 on current surfaces;
+- [ ] control count remains 161 core;
+- [ ] CP.5.MCP profile count remains 19;
+- [ ] MCP primary binding is `2026-07-28`;
+- [ ] legacy compatibility binding is `2025-11-25`;
+- [ ] `server/discover` is not described as mandatory;
+- [ ] `Mcp-Session-Id` is not described as identity;
+- [ ] MCP-19 does not claim conformance from opaque bearer-token possession alone;
+- [ ] NEXUS is described as a reference implementation, not mandatory;
+- [ ] NEXUS version remains v0.3;
+- [ ] Gateway version remains v3.0;
+- [ ] NEXUS MCP adapter is explicitly described as not production-ready;
+- [ ] machine manifest validates;
+- [ ] examples and research indexes validate;
+- [ ] scanner invariants validate;
+- [ ] NEXUS persistence tests validate;
+- [ ] Python 3.10, 3.11, and 3.12 NEXUS tests pass;
+- [ ] reference examples pass smoke tests;
+- [ ] documentation checks pass;
+- [ ] Skill Trust Gate has no blocking failure.
+
+---
+
+# Fast reference
+
+## Framework
+
+- [AI SAFE² v3.1](../README.md)
+- [Cross-Pillar Governance](../00-cross-pillar/)
+- [CP.5.MCP](../00-cross-pillar/cp5_mcp_server_security.md)
+- [AISM](../AISM/)
+- [Dashboard](https://cyberstrategyinstitute.github.io/ai-safe2-framework/dashboard/)
+
+## Implementation
+
+- [NEXUS](../NEXUS/)
+- [Scanner](../scanner/)
+- [MCP Security Toolkit](../examples/mcp-security-toolkit/)
+- [AI SAFE² MCP Server](../skills/mcp/)
+- [Examples](../examples/)
+
+## Machine consumption
+
+- [AGENTS.md](../AGENTS.md)
+- [Manifest](../ai-safe2.manifest.json)
+- [Core Controls JSON](../skills/mcp/data/ai-safe2-controls-v3.0.json)
+- [MCP Profile JSON](../skills/mcp/data/mcp-profile-v3.1.json)
+
+## Evidence
+
+- [Research](../research/)
+- [Research 023](../research/023_mcp-server-security-profile.md)
+- [Research 024](../research/024_mcp_consumer_protection.md)
+- [Challenge Lab](../challenges/)
+
+## External
+
+- [AI SAFE²](https://cyberstrategyinstitute.com/ai-safe2/)
+- [NEXUS](https://cyberstrategyinstitute.com/nexus/)
+- [Implementation Toolkit](https://secure.cyberstrategyinstitute.com/ai-safe-implementation-toolkit/)
+- [MCP 2026-07-28 Specification](https://modelcontextprotocol.io/specification/2026-07-28)
+
+---
+
+## The v3.1 operating principle
+
+**Policy defines intent. Engineering guarantees reality.**
+
+If governance is not enforced at runtime, it is not governance.
+
+v3.1 adds one more requirement to that idea: the governance boundary must remain valid even when the protocol changes underneath it.
+
+---
+
+Framework content CC-BY-SA 4.0. Code MIT. NEXUS Apache 2.0.
+
+*Cyber Strategy Institute*

--- a/guides/v3.1-release-overview.md
+++ b/guides/v3.1-release-overview.md
@@ -39,9 +39,9 @@ v3.0 transformed AI SAFE² into a governance operating system. v3.1 hardens that
 
 ---
 
-# Part I: What changed
+## Part I: What changed
 
-## 1. The design defect v3.1 fixes
+### 1. The design defect v3.1 fixes
 
 The MCP `2026-07-28` specification removed the session-oriented assumptions that earlier CP.5.MCP controls had relied on.
 
@@ -67,7 +67,7 @@ The normative rule is:
 
 This rule applies beyond MCP. It is the design requirement for every future CP.5 protocol or platform profile.
 
-## 2. Framework-owned constructs
+### 2. Framework-owned constructs
 
 Controls now bind to concepts AI SAFE² owns and can preserve across protocol revisions:
 
@@ -84,7 +84,7 @@ Controls now bind to concepts AI SAFE² owns and can preserve across protocol re
 
 The protocol supplies transport and capability semantics. It no longer owns the governance boundary.
 
-## 3. Three enforcement planes
+### 3. Three enforcement planes
 
 v3.1 formalizes three distinct enforcement planes.
 
@@ -96,11 +96,9 @@ v3.1 formalizes three distinct enforcement planes.
 
 A control can span more than one plane, but evidence remains plane-specific. Passing an east-west challenge does not establish agent-to-tool conformance.
 
-## 4. Protocol-independent persistence
+### 4. Protocol-independent persistence
 
 v3.1 standardizes persistence language so governance is not attached to a transport session.
-
-Canonical scopes:
 
 | Scope | Meaning |
 |:---|:---|
@@ -121,9 +119,9 @@ These aliases are compatibility vocabulary. They are not identity or authorizati
 
 ---
 
-# Part II: The CP.5.MCP v3.1 profile
+## Part II: The CP.5.MCP v3.1 profile
 
-## 1. Control count model
+### 1. Control count model
 
 AI SAFE² remains a **161-control framework**.
 
@@ -136,7 +134,7 @@ Machine-readable sources:
 - [161-control core dataset](../skills/mcp/data/ai-safe2-controls-v3.0.json)
 - [19-control MCP v3.1 profile](../skills/mcp/data/mcp-profile-v3.1.json)
 
-## 2. Existing controls re-anchored
+### 2. Existing controls re-anchored
 
 Five controls required material semantic changes because they were previously tied to session concepts:
 
@@ -150,41 +148,33 @@ They now bind to verified principals and framework-owned governance state.
 
 MCP-8 is the clearest example. A spend ceiling expressed per transport session is not enforceable if no transport session exists. A spend ceiling tied to a verified principal, capability, delegation context, or governed accounting identity survives the protocol revision.
 
-## 3. Six new controls
+### 3. Six new controls
 
-### MCP-14: Extension Capability Negotiation
+#### MCP-14: Extension Capability Negotiation
 
 Requires explicit negotiation and validation of extension capabilities rather than silently assuming optional behavior is present or trustworthy.
 
-### MCP-15: Header and Body Assertion Integrity
+#### MCP-15: Header and Body Assertion Integrity
 
-Protects against authorization and routing decisions being made from one asserted operation while the server dispatches another.
+Protects against authorization and routing decisions being made from one asserted operation while the server dispatches another. A mismatch between header-level assertions and body content is treated as a security event.
 
-A mismatch between header-level method/name assertions and body content is treated as a security event, not benign drift.
-
-### MCP-16: State Handle Binding and Lifecycle
+#### MCP-16: State Handle Binding and Lifecycle
 
 Requires governed state handles to be bound to the correct principal and lifecycle, without treating the handle itself as identity.
 
-### MCP-17: MRTR Round-Trip Integrity and Replay Resistance
+#### MCP-17: MRTR Round-Trip Integrity and Replay Resistance
 
 Governs Multi Round-Trip Request answers, replay resistance, response binding, and consent-state integrity.
 
-This matters when human approval, Class-H authorization, or delegated decision state is carried through the round-trip.
-
-### MCP-18: Catalog Cache Integrity and Provenance Revalidation
+#### MCP-18: Catalog Cache Integrity and Provenance Revalidation
 
 Addresses cache poisoning, stale revocation, tool catalog drift, schema drift, and untrusted server-declared TTL behavior.
 
-The local consumer must retain authority over acceptable cache duration and provenance revalidation.
+#### MCP-19: Authorization Chain Integrity
 
-### MCP-19: Authorization Chain Integrity
+Requires intended-resource, audience, or equivalent authorization binding through the protected dispatch path and adds SSRF/resource-boundary requirements. Possession of an opaque bearer token is not sufficient evidence.
 
-Requires intended-resource, audience, or equivalent authorization binding through the protected dispatch path and adds SSRF/resource-boundary requirements.
-
-Possession of an opaque bearer token is not sufficient evidence.
-
-## 4. Compatibility model
+### 4. Compatibility model
 
 Primary specification binding:
 
@@ -203,53 +193,23 @@ Important behavior:
 - it is not identity;
 - it is not the authorization boundary.
 
-## 5. New threat emphasis
+### 5. New threat emphasis
 
-v3.1 explicitly treats agent-to-tool protocol exploitation as a first-class threat surface.
-
-The release work includes cases for:
-
-- header/body assertion desynchronization;
-- stale or poisoned catalog caches;
-- catalog and schema drift;
-- OAuth resource and audience confusion;
-- replay;
-- endpoint identity confusion and local impersonation;
-- redirect and resource SSRF;
-- state-handle identity misuse.
+The v3.1 work includes cases for header/body assertion desynchronization, stale or poisoned catalog caches, catalog/schema drift, OAuth resource and audience confusion, replay, endpoint identity confusion, redirect/resource SSRF, and state-handle identity misuse.
 
 ---
 
-# Part III: NEXUS and reference implementation
+## Part III: NEXUS and reference implementation
 
-## 1. NEXUS positioning
-
-AI SAFE² and NEXUS serve different roles.
+### 1. NEXUS positioning
 
 **AI SAFE²** defines governance outcomes, controls, evidence expectations, and conformance requirements.
 
 **NEXUS** is Cyber Strategy Institute's first-party reference implementation for enforcing those requirements across agent-to-agent and agent-to-tool interactions.
 
-NEXUS is not mandatory for AI SAFE² conformance.
+NEXUS is not mandatory for AI SAFE² conformance. Another implementation may conform if it demonstrably satisfies the applicable control outcome and produces the required evidence.
 
-Another implementation may conform if it demonstrably satisfies the applicable control outcome and produces the required evidence.
-
-This is the correct relationship:
-
-```text
-AI SAFE² requirement
-        |
-        v
-reference implementation or alternative implementation
-        |
-        v
-runtime evidence
-        |
-        v
-conformance claim
-```
-
-## 2. Component versions remain independent
+### 2. Component versions remain independent
 
 | Component | Version in this release |
 |:---|:---|
@@ -259,33 +219,17 @@ conformance claim
 
 Repository branding does not overwrite component provenance.
 
-A Gateway v3.0 evidence chain remains Gateway v3.0 evidence. NEXUS v0.3 remains NEXUS v0.3.
+### 3. NEXUS persistence compatibility
 
-## 3. NEXUS persistence compatibility
+The NEXUS Memory SDK now emits the canonical persistence vocabulary while accepting legacy serialized values. The migration path preserves old callers and evidence consumers without allowing old terms to remain the normative governance model.
 
-The NEXUS Memory SDK now emits the canonical persistence vocabulary while accepting legacy serialized values.
+Updated surfaces include the Memory SDK, Guardian schema, OPA authorization policy, OPA invariants, compatibility regression tests, and reference examples.
 
-The migration path is designed to preserve old callers and evidence consumers without allowing old terms to remain the normative governance model.
+### 4. ACS bridge example
 
-Updated implementation surfaces include:
+The ACS bridge reference example now runs under Python 3.10+, demonstrates `handle_scoped`, emits governed state-handle evidence, and preserves legitimate ACS protocol correlation semantics.
 
-- NEXUS Memory SDK;
-- Guardian schema;
-- OPA authorization policy;
-- OPA invariants;
-- compatibility regression tests;
-- reference examples.
-
-## 4. ACS bridge example
-
-The ACS bridge reference example now:
-
-- runs under the project's Python 3.10+ support model;
-- demonstrates `handle_scoped` rather than the legacy `CROSS_SESSION` term;
-- emits the governed state-handle evidence fields;
-- preserves ACS protocol correlation semantics where they are legitimately protocol-owned.
-
-## 5. MCP adapter status
+### 5. MCP adapter status
 
 The NEXUS MCP adapter is a fail-closed interface scaffold.
 
@@ -293,51 +237,26 @@ The NEXUS MCP adapter is a fail-closed interface scaffold.
 
 Unimplemented enforcement paths raise rather than silently allowing traffic.
 
-That distinction is explicitly represented in both human and machine-facing release material so downstream users and agents cannot reasonably infer production conformance from the existence of the adapter.
-
 ---
 
-# Part IV: Scanner, evidence, and validation
+## Part IV: Scanner, evidence, and validation
 
-## 1. Scanner rule expansion
+### 1. Scanner rule expansion
 
 The v3.1 scanner registry contains **64 total rules**:
 
 - 52 pre-existing rules;
 - 12 new grouped CP.5.MCP v3.1 rules.
 
-The scanner now recognizes v3.1 MCP patterns without pretending that static analysis can prove every deployment property.
+MCP-19 resource/audience findings remain advisory when runtime evidence is required.
 
-MCP-19 resource/audience findings therefore remain advisory when runtime evidence is required.
+### 2. Scanner is evidence, not conformance by itself
 
-## 2. Scanner is evidence, not conformance by itself
+A scanner result does not by itself prove runtime policy enforcement, delegated authority correctness, intended-resource binding, human authorization integrity, runtime catalog revalidation, or full framework conformance.
 
-A scanner result is one evidence source.
+### 3. Challenge Lab changes
 
-It does not prove:
-
-- runtime policy enforcement;
-- delegated authority correctness;
-- intended-resource binding at dispatch;
-- human authorization integrity;
-- runtime catalog revalidation;
-- full framework conformance.
-
-This separation is important for both humans and automated compliance systems.
-
-## 3. Challenge Lab changes
-
-The Challenge Lab now separates:
-
-- `challenge_maturity`;
-- `framework_profile_conformance`;
-- enforcement plane;
-- implementation under test;
-- evidence required for the claim.
-
-Challenge 001 includes new v3.1 MCP attack cases and evidence fields.
-
-The framework is the subject of the experiment, not the source of its own proof.
+The Challenge Lab now separates `challenge_maturity`, `framework_profile_conformance`, enforcement plane, implementation under test, and evidence required for the claim.
 
 Useful links:
 
@@ -345,37 +264,17 @@ Useful links:
 - [Challenge 001](../challenges/001-anthropic-multi-agent-turf-war/)
 - [Challenge Evidence](../challenges/001-anthropic-multi-agent-turf-war/EVIDENCE.md)
 
-## 4. Release validation gates
+### 4. Release validation gates
 
-The v3.1 release work adds or strengthens validation for:
+The v3.1 release work adds or strengthens validation for repository UX, examples/research indexes, scanner invariants, NEXUS persistence, MCP profile/dashboard parity, 161/19 count invariants, Python 3.10-3.12 NEXUS tests, correctness lint, schemas, reference examples, compliance checks, documentation, Skill Trust Gate, and machine-entry/manifest integrity.
 
-1. repository UX and navigation consistency;
-2. examples index integrity;
-3. research index completeness;
-4. scanner v3.1 rule invariants;
-5. NEXUS persistence compatibility;
-6. MCP profile/dashboard data parity;
-7. 161-core/19-profile control count invariants;
-8. NEXUS tests on Python 3.10, 3.11, and 3.12;
-9. release-critical Python correctness;
-10. NEXUS schema validation;
-11. NEXUS reference-example smoke tests;
-12. NEXUS v0.3 implementation/compliance checks;
-13. documentation validation;
-14. Skill Trust Gate checks;
-15. machine-entry and manifest integrity.
-
-The objective is not merely to make CI green. The gates encode release claims so the repository fails when the release narrative and the implementation diverge.
+The gates encode release claims so the repository fails when the release narrative and implementation diverge.
 
 ---
 
-# Part V: One repository, one product experience
+## Part V: One repository, one product experience
 
-v3.1 includes a repository-wide UX consistency pass.
-
-The target user experience is simple: a user should be able to land anywhere in the repository and understand where they are, what version applies, how to get back to the framework, and which adjacent resources matter.
-
-## 1. Standard color language
+### 1. Standard color language
 
 - **CSI Orange `#F6921E`**: current framework release and version context
 - **CSI Maroon `#820F1A`**: framework, governance, module, and surface identity
@@ -383,180 +282,87 @@ The target user experience is simple: a user should be able to land anywhere in 
 - red/amber/yellow: severity and risk only
 - green: pass or verified states only
 
-The standard is documented in:
+See the [Repository UX Standard](../docs/REPOSITORY-UX-STANDARD.md).
 
-[Repository UX Standard](../docs/REPOSITORY-UX-STANDARD.md)
+### 2. Canonical navigation
 
-## 2. Canonical navigation
+Common entry points include Framework Home, Cross-Pillar Governance, AISM, NEXUS, and context-specific parent or adjacent resources. The canonical Cross-Pillar path is `00-cross-pillar/`.
 
-Common entry points include:
+### 3. Examples and research
 
-- Framework Home;
-- Cross-Pillar Governance;
-- AISM;
-- NEXUS;
-- context-specific parent or adjacent resources.
+All 18 direct example README surfaces and all 24 numbered research notes now use a consistent v3.1 shell with canonical indexes while preserving legitimate historical provenance.
 
-The old broken `cross-pillar/` path pattern is replaced by the canonical `00-cross-pillar/` path.
-
-## 3. Examples
-
-All 18 direct example README surfaces now have a consistent v3.1 shell and an indexed landing page:
-
-[Examples Index](../examples/)
-
-Historical implementation references are preserved when they accurately describe provenance.
-
-## 4. Research
-
-All 24 numbered research notes now have consistent navigation and a canonical index:
-
-[Research Index](../research/)
-
-The research body remains evidence and publication history. Current normative implementation guidance comes from the v3.1 framework surfaces.
+- [Examples Index](../examples/)
+- [Research Index](../research/)
 
 ---
 
-# Part VI: Agent and bot consumption
+## Part VI: Agent and bot consumption
 
-This is one of the most important distribution changes in v3.1.
+v3.1 adds deterministic machine discovery so automated consumers no longer need to infer authority and structure from prose.
 
-Before this release, an AI agent could use the repository, but it had to infer authority and structure from human prose.
+### 1. AGENTS.md
 
-v3.1 adds deterministic machine discovery.
+[AGENTS.md](../AGENTS.md) tells automated consumers what to parse first, how to distinguish core controls from profiles, how to classify enforcement planes, how to interpret persistence and compatibility, and how to avoid false conformance claims.
 
-## 1. AGENTS.md
+### 2. ai-safe2.manifest.json
 
-[AGENTS.md](../AGENTS.md) is the root machine-consumption guide.
+[ai-safe2.manifest.json](../ai-safe2.manifest.json) exposes framework version, control counts, component versions, normative paths, machine-readable datasets, enforcement planes, persistence vocabulary, compatibility rules, implementation status, and conformance boundaries.
 
-It tells automated consumers:
+### 3. Stable core plus overlay model
 
-- what to parse first;
-- which datasets are authoritative for which purpose;
-- how to distinguish core controls from profiles;
-- how to classify enforcement planes;
-- how to interpret persistence;
-- how to handle legacy aliases;
-- how to treat `server/discover`;
-- how to treat bearer tokens and MCP-19;
-- how to treat the NEXUS MCP adapter;
-- how to avoid false conformance claims.
+The stable core is `skills/mcp/data/ai-safe2-controls-v3.0.json`, representing the unchanged 161-control taxonomy.
 
-## 2. ai-safe2.manifest.json
+The current MCP overlay is `skills/mcp/data/mcp-profile-v3.1.json`, containing the 19 CP.5.MCP controls.
 
-[ai-safe2.manifest.json](../ai-safe2.manifest.json) is the machine-readable root manifest.
+An automated consumer must not merge the two counts into a 180-control framework total.
 
-It exposes:
+### 4. Manifest integrity gate
 
-- framework version;
-- control counts;
-- component versions;
-- normative paths;
-- machine-readable datasets;
-- enforcement planes;
-- persistence vocabulary;
-- compatibility rules;
-- implementation status;
-- conformance boundaries;
-- scanner and challenge resources.
-
-## 3. Stable core plus overlay model
-
-The data model is intentionally layered.
-
-### Stable core
-
-`skills/mcp/data/ai-safe2-controls-v3.0.json`
-
-This remains the canonical 161-control dataset because the core taxonomy is unchanged from v3.0.
-
-### Current profile overlay
-
-`skills/mcp/data/mcp-profile-v3.1.json`
-
-This contains the 19 current CP.5.MCP profile controls.
-
-An automated consumer should not merge the two counts into a 180-control framework total.
-
-## 4. Manifest integrity gate
-
-A dedicated CI job validates machine-facing release claims against the actual repository.
-
-It checks, among other things:
-
-- framework version;
-- component versions;
-- required paths;
-- 161/19 count split;
-- MCP spec version;
-- profile/dashboard parity;
-- canonical persistence scopes;
-- NEXUS non-mandatory positioning;
-- explicit non-production status of the MCP adapter.
-
-This makes agent-readiness a tested release property rather than a documentation promise.
+A dedicated CI job validates framework/component versions, required paths, the 161/19 split, MCP spec version, profile/dashboard parity, canonical persistence scopes, NEXUS non-mandatory positioning, and explicit non-production status of the MCP adapter.
 
 ---
 
-# Part VII: What v3.1 does not change
+## Part VII: What v3.1 does not change
 
-## 1. The core framework remains 161 controls
+### 1. The core framework remains 161 controls
 
-v3.1 does not add the MCP profile controls to the framework total.
+The framework remains five operational pillars plus Cross-Pillar Governance CP.1 through CP.10 and 161 core controls.
 
-The framework remains:
+### 2. CP.11 UAS remains an overlay
 
-- five operational pillars;
-- Cross-Pillar Governance CP.1 through CP.10;
-- 161 core controls.
+UAS remains a compliance overlay and does not add 27 independent controls to the core framework count.
 
-## 2. CP.11 UAS remains an overlay
+### 3. Historical v3.0 references are not automatically wrong
 
-The UAS material does not add 27 independent controls to the core framework count.
+Current normative framework guidance is v3.1. Historical publication or component provenance retains the actual version when accurate.
 
-It remains a compliance overlay applied to the framework.
+### 4. Gateway remains v3.0
 
-## 3. Historical v3.0 references are not automatically wrong
+Gateway does not become v3.1 until the component receives a separately tested release.
 
-Some documents, examples, and evidence correctly say v3.0 because that is when the underlying capability or result was introduced.
+### 5. NEXUS remains v0.3
 
-v3.1 preserves those references when they are provenance.
-
-The distinction is:
-
-- **current normative framework guidance** -> v3.1;
-- **historical publication or component provenance** -> preserve the actual version.
-
-## 4. Gateway does not become v3.1
-
-Gateway remains v3.0 until the component itself receives a separately tested release.
-
-## 5. NEXUS does not become v3.1
-
-NEXUS remains v0.3.
-
-The framework release and implementation release are different version axes.
+The framework release and implementation release remain different version axes.
 
 ---
 
-# Part VIII: How to use v3.1
+## Part VIII: How to use v3.1
 
-## If you are an executive, CISO, or governance owner
+### Executives, CISOs, and governance owners
 
-Start here:
+Start with:
 
 1. [Framework README](../README.md)
 2. [Cross-Pillar Governance](../00-cross-pillar/)
 3. [AISM](../AISM/)
 4. [Challenge Lab](../challenges/)
 
-Key question to ask:
+Key question: **Where is the enforcement point, and what evidence proves the control operates there?**
 
-**Where is the enforcement point, and what evidence proves the control operates there?**
+### Engineers and platform teams
 
-## If you are an engineer or platform team
-
-Start here:
+Start with:
 
 1. [CP.5.MCP Security Profile](../00-cross-pillar/cp5_mcp_server_security.md)
 2. [Scanner](../scanner/)
@@ -564,41 +370,21 @@ Start here:
 4. [NEXUS](../NEXUS/)
 5. [Examples](../examples/)
 
-Key question to ask:
+Key question: **Which plane am I enforcing, and what framework-owned identity/state construct survives protocol changes?**
 
-**Which plane am I enforcing, and what framework-owned identity/state construct survives protocol changes?**
+### MCP server or client operators
 
-## If you operate an MCP server or client
+Start with the [MCP profile](../00-cross-pillar/cp5_mcp_server_security.md), [Research 023](../research/023_mcp-server-security-profile.md), [Research 024](../research/024_mcp_consumer_protection.md), and [MCP Toolkit](../examples/mcp-security-toolkit/).
 
-Start here:
+Pay particular attention to MCP-15 through MCP-19.
 
-1. [MCP profile](../00-cross-pillar/cp5_mcp_server_security.md)
-2. [Research 023](../research/023_mcp-server-security-profile.md)
-3. [Research 024](../research/024_mcp_consumer_protection.md)
-4. [MCP Toolkit](../examples/mcp-security-toolkit/)
+### Autonomous-agent builders
 
-Pay special attention to:
+Start with [AISM](../AISM/), [NEXUS](../NEXUS/), [Examples](../examples/), and the [Challenge Lab](../challenges/). Classify the ACT tier before treating implementation guidance as complete.
 
-- MCP-15 assertion integrity;
-- MCP-16 state-handle binding;
-- MCP-17 replay and MRTR integrity;
-- MCP-18 cache provenance;
-- MCP-19 intended-resource/audience binding.
+### AI agents, coding assistants, compliance bots, and retrieval systems
 
-## If you are building an autonomous agent
-
-Start here:
-
-1. [AISM](../AISM/)
-2. [NEXUS](../NEXUS/)
-3. [Examples](../examples/)
-4. [Challenge Lab](../challenges/)
-
-Classify the agent's ACT tier before treating implementation guidance as complete.
-
-## If you are an AI agent, coding assistant, compliance bot, or retrieval system
-
-Start here:
+Start with:
 
 1. [AGENTS.md](../AGENTS.md)
 2. [ai-safe2.manifest.json](../ai-safe2.manifest.json)
@@ -607,48 +393,40 @@ Start here:
 
 Do not infer framework conformance from scanner results, component presence, or protocol session state.
 
-## If you want to challenge the framework
+### Framework challengers and researchers
 
-Start here:
-
-1. [Challenge Lab](../challenges/)
-2. [Challenge 001](../challenges/001-anthropic-multi-agent-turf-war/)
-3. [Evidence requirements](../challenges/001-anthropic-multi-agent-turf-war/EVIDENCE.md)
-
-The objective is falsification, not confirmation.
+Start with [Challenge Lab](../challenges/), [Challenge 001](../challenges/001-anthropic-multi-agent-turf-war/), and its [Evidence requirements](../challenges/001-anthropic-multi-agent-turf-war/EVIDENCE.md). The objective is falsification, not confirmation.
 
 ---
 
-# Release readiness checklist
+## Release readiness checklist
 
-Before publishing v3.1, verify all of the following:
-
-- [ ] framework version is represented as v3.1.0 on current surfaces;
-- [ ] control count remains 161 core;
-- [ ] CP.5.MCP profile count remains 19;
-- [ ] MCP primary binding is `2026-07-28`;
-- [ ] legacy compatibility binding is `2025-11-25`;
-- [ ] `server/discover` is not described as mandatory;
-- [ ] `Mcp-Session-Id` is not described as identity;
-- [ ] MCP-19 does not claim conformance from opaque bearer-token possession alone;
-- [ ] NEXUS is described as a reference implementation, not mandatory;
-- [ ] NEXUS version remains v0.3;
-- [ ] Gateway version remains v3.0;
-- [ ] NEXUS MCP adapter is explicitly described as not production-ready;
-- [ ] machine manifest validates;
-- [ ] examples and research indexes validate;
-- [ ] scanner invariants validate;
-- [ ] NEXUS persistence tests validate;
-- [ ] Python 3.10, 3.11, and 3.12 NEXUS tests pass;
-- [ ] reference examples pass smoke tests;
-- [ ] documentation checks pass;
+- [ ] Framework version is v3.1.0 on current surfaces.
+- [ ] Core count remains 161.
+- [ ] CP.5.MCP profile count remains 19.
+- [ ] MCP primary binding is `2026-07-28`.
+- [ ] Legacy compatibility binding is `2025-11-25`.
+- [ ] `server/discover` is not described as mandatory.
+- [ ] `Mcp-Session-Id` is not described as identity.
+- [ ] MCP-19 does not claim conformance from opaque bearer-token possession alone.
+- [ ] NEXUS is described as a reference implementation, not mandatory.
+- [ ] NEXUS remains v0.3.
+- [ ] Gateway remains v3.0.
+- [ ] NEXUS MCP adapter is explicitly not production-ready.
+- [ ] Machine manifest validates.
+- [ ] Examples and research indexes validate.
+- [ ] Scanner invariants validate.
+- [ ] NEXUS persistence tests validate.
+- [ ] Python 3.10, 3.11, and 3.12 NEXUS tests pass.
+- [ ] Reference examples pass smoke tests.
+- [ ] Documentation checks pass.
 - [ ] Skill Trust Gate has no blocking failure.
 
 ---
 
-# Fast reference
+## Fast reference
 
-## Framework
+### Framework
 
 - [AI SAFE² v3.1](../README.md)
 - [Cross-Pillar Governance](../00-cross-pillar/)
@@ -656,7 +434,7 @@ Before publishing v3.1, verify all of the following:
 - [AISM](../AISM/)
 - [Dashboard](https://cyberstrategyinstitute.github.io/ai-safe2-framework/dashboard/)
 
-## Implementation
+### Implementation
 
 - [NEXUS](../NEXUS/)
 - [Scanner](../scanner/)
@@ -664,21 +442,21 @@ Before publishing v3.1, verify all of the following:
 - [AI SAFE² MCP Server](../skills/mcp/)
 - [Examples](../examples/)
 
-## Machine consumption
+### Machine consumption
 
 - [AGENTS.md](../AGENTS.md)
 - [Manifest](../ai-safe2.manifest.json)
 - [Core Controls JSON](../skills/mcp/data/ai-safe2-controls-v3.0.json)
 - [MCP Profile JSON](../skills/mcp/data/mcp-profile-v3.1.json)
 
-## Evidence
+### Evidence
 
 - [Research](../research/)
 - [Research 023](../research/023_mcp-server-security-profile.md)
 - [Research 024](../research/024_mcp_consumer_protection.md)
 - [Challenge Lab](../challenges/)
 
-## External
+### External
 
 - [AI SAFE²](https://cyberstrategyinstitute.com/ai-safe2/)
 - [NEXUS](https://cyberstrategyinstitute.com/nexus/)
@@ -693,7 +471,7 @@ Before publishing v3.1, verify all of the following:
 
 If governance is not enforced at runtime, it is not governance.
 
-v3.1 adds one more requirement to that idea: the governance boundary must remain valid even when the protocol changes underneath it.
+v3.1 adds one more requirement: the governance boundary must remain valid even when the protocol changes underneath it.
 
 ---
 


### PR DESCRIPTION
## AI SAFE² v3.1 release package

Adds the two final public release documents on a clean branch from current `main`.

### Files

- `ANNOUNCEMENT-v3.1.md`
  - fast-action release announcement
  - CSI orange/maroon/gray badge language
  - direct links to framework, MCP profile, NEXUS, scanner, examples, research, Challenge Lab, dashboard, agent entry points, and machine-readable data
  - reflects final scanner total of 64 rules and explicit NEXUS MCP adapter non-production status

- `guides/v3.1-release-overview.md`
  - full v3.1 guide modeled on `guides/v3-release-overview.md`
  - explains protocol-independent governance, three enforcement planes, persistence vocabulary, MCP-14 through MCP-19, NEXUS positioning, scanner/evidence model, repository UX, and agent/bot consumption
  - includes audience-specific fast paths and a release-readiness checklist

### Canonical release facts

- AI SAFE² Framework v3.1.0
- 161 core controls
- CP.5.MCP profile: 19 controls
- MCP `2026-07-28` primary binding
- MCP `2025-11-25` legacy compatibility window
- NEXUS v0.3 reference implementation
- Gateway v3.0 component provenance
- scanner registry: 64 total rules, 52 pre-existing + 12 v3.1 MCP rules
- NEXUS MCP adapter: not production-ready
- machine entry: `AGENTS.md` + `ai-safe2.manifest.json`

Documentation-only follow-on to the merged v3.1 release PR.